### PR TITLE
Docker useful features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tunables
 * `upstart_environment` (list) - Environment data
 * `upstart_environment_global` (boolean) - Should env vars be global to all upstart scripts? 
 * `upstart_pre_start` (list) - Commands to run prior to starting
+* `upstart_pre_stop` (list) - Commands to run before stopping (useful for docker)
 * `upstart_post_stop` (list) - Commands to run after stopping
 * `upstart_script` (list) - Script to run
 * `upstart_respawn` (boolean) - Should you respawn process on accidental shutdown?
@@ -52,3 +53,4 @@ Contributors
 * Aaron Pederson
 * Justin Scott
 * Steven Harradine
+* Ryan Mills

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ upstart_environment: no
 upstart_environment_global: yes
 upstart_pre_start: no
 upstart_post_stop: no
+upstart_pre_stop: no
 upstart_script: no
 
 upstart_respawn: no

--- a/templates/etc/init/template
+++ b/templates/etc/init/template
@@ -52,6 +52,15 @@ end script
 exec start-stop-daemon --start --chuid {{ upstart_user }} --group {{ upstart_group }} --make-pidfile --pidfile {{ upstart_pidfile_path }} --exec {{ upstart_exec_path }}{{ ' -- '~upstart_exec_flags|join(' ') if upstart_exec_flags else '' }} {{ '2>&1' if upstart_capture_errors else '' }} >> {{ upstart_log_path }}
 {% endif %}
 
+{% if upstart_pre_stop is iterable %}
+pre-stop script
+{%   for command in upstart_pre_stop %}
+  {{ command }}
+{%   endfor %}
+end script
+{% endif %}
+
+
 post-stop script
   rm {{ upstart_pidfile_path }}
 {% if upstart_post_stop is iterable %}

--- a/templates/etc/init/template
+++ b/templates/etc/init/template
@@ -44,6 +44,7 @@ end script
 
 {% if upstart_script is iterable %}
 script
+  touch {{upstart_pidfile_path}}
 {%   for command in upstart_script %}
   {{ command }}
 {%   endfor %}

--- a/templates/etc/init/template
+++ b/templates/etc/init/template
@@ -44,7 +44,7 @@ end script
 
 {% if upstart_script is iterable %}
 script
-  touch {{upstart_pidfile_path}}
+  touch {{ upstart_pidfile_path }}
 {%   for command in upstart_script %}
   {{ command }}
 {%   endfor %}


### PR DESCRIPTION
To enable docker usage, added support for upstart_pre_script, and touched the pid file on creation. 

This allows docker -a <x> as the start, and the stop as docker stop <x> if you put this in the pre_script

eg.)
  roles:
    - role: koancode.upstart
      upstart_name: youtrack
      upstart_description: "Upstart for YouTrack"
      upstart_start_on:
        - filesystem
        - started docker
      upstart_boolean: true
      upstart_script:
        - /usr/bin/docker start -a youtrack >>/var/log/youtrack/docker-youtrack.log 2>&1
      upstart_pre_stop:
        - /usr/bin/docker stop youtrack